### PR TITLE
Add optional alphabetical ordering in schema dump

### DIFF
--- a/lib/fx/configuration.rb
+++ b/lib/fx/configuration.rb
@@ -15,9 +15,18 @@ module Fx
     # @return Boolean
     attr_accessor :dump_functions_at_beginning_of_schema
 
+    # Orders functions and triggers alphabetically in the schema dump.
+    # When set to true, functions and triggers will appear in alphabetical
+    # order within the schema.rb file.
+    #
+    # Defaults to false
+    # @return Boolean
+    attr_accessor :dump_functions_and_triggers_alphabetically
+
     def initialize
       @database = Fx::Adapters::Postgres.new
       @dump_functions_at_beginning_of_schema = false
+      @dump_functions_and_triggers_alphabetically = false
     end
   end
 end

--- a/lib/fx/schema_dumper.rb
+++ b/lib/fx/schema_dumper.rb
@@ -40,11 +40,15 @@ module Fx
     end
 
     def dumpable_functions_in_database
-      @_dumpable_functions_in_database ||= Fx.database.functions
+      @_dumpable_functions_in_database ||= dumpables_order(Fx.database.functions)
     end
 
     def dumpable_triggers_in_database
-      @_dumpable_triggers_in_database ||= Fx.database.triggers
+      @_dumpable_triggers_in_database ||= dumpables_order(Fx.database.triggers)
+    end
+
+    def dumpables_order(list)
+      Fx.configuration.dump_functions_and_triggers_alphabetically ? list.sort : list
     end
   end
 end


### PR DESCRIPTION
Active Record’s schema dumping convention is to output all elements in a consistent, name-sorted order. However, F(x) currently fetches functions and triggers by their insertion order (oid), which can lead to order inconsistencies in db/schema.rb when working with database dumps from production or staging.

Restoring from a pg_dump, which outputs functions and triggers alphabetically, often causes unnecessary schema churn when regenerating db/schema.rb locally:

- Engineer 1 adds function `a()` alongside an existing function `b()`, resulting in `db/schema.rb` listing them as `b(), a()`.
- Engineer 2, needing a production data refresh, restores their database from a pg_dump, which reorders the functions as `a(), b()`.
- Engineer 1 continues working locally, regenerating `db/schema.rb` to `b(), a()` again.

The new `dump_functions_and_triggers_alphabetically` configuration provides an option to mitigate this. When enabled, functions and triggers are ordered alphabetically at the `SchemaDumper`. This ensures compatibility across database adapters while maintaining the default behavior if the option is not set.

By matching the alphabetical order pattern of `db/schema.rb`, this configuration reduces schema churn for teams working with database dumps across different environments.